### PR TITLE
Add recommended compile flags to transcoder + -fno-sanitize=undefined

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,12 +39,16 @@ pub fn build(b: *std.Build) !void {
     }
 
     if (build_transcoder) {
-        lib.addCSourceFiles(.{ .files = &transcoder_sources, .flags = &.{
-            "-Wno-deprecated-builtins",
-            "-Wno-deprecated-declarations",
-            "-Wno-array-bounds",
-            "-fno-strict-aliasing",
-        } });
+        lib.addCSourceFiles(.{
+            .files = &transcoder_sources,
+            .flags = &.{
+                "-Wno-deprecated-builtins",
+                "-Wno-deprecated-declarations",
+                "-Wno-array-bounds",
+                "-fno-strict-aliasing",
+                "-fno-sanitize=undefined", // there is some UB in transcoder
+            },
+        });
         lib.installHeadersDirectoryOptions(.{
             .source_dir = .{ .path = "transcoder" },
             .install_dir = .header,

--- a/build.zig
+++ b/build.zig
@@ -43,6 +43,7 @@ pub fn build(b: *std.Build) !void {
             "-Wno-deprecated-builtins",
             "-Wno-deprecated-declarations",
             "-Wno-array-bounds",
+            "-fno-strict-aliasing",
         } });
         lib.installHeadersDirectoryOptions(.{
             .source_dir = .{ .path = "transcoder" },


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Hi, I tried using this via `mach-basisu` and encountered a UB trap when transcoder is build in Debug mode. ReleaseFast works fine for me, but I wanted to let you know about it and provide a workaround.

`-fno-strict-aliasing` comes from a recommendadtion on basisu's [wiki page](https://github.com/BinomialLLC/basis_universal/wiki/How-to-Use-and-Configure-the-Transcoder). Not sure if it actually changes anything, but they recommend it.